### PR TITLE
Respond to GET requests with OK for healthchecks

### DIFF
--- a/lib/highcharts-convert.js
+++ b/lib/highcharts-convert.js
@@ -832,11 +832,13 @@
           response.write(msg);
           response.close();
         }
-        var jsonStr = request.postRaw || request.post;
+        var jsonStr = request.postRaw || request.post || '{}';
         var params;
         try {
           params = JSON.parse(jsonStr);
-          if (params.status) {
+          if (request.method === 'GET') {
+            onSuccess('OK');
+          } else if (params.status) {
             // for server health validation
             response.statusCode = 200;
             response.write('OK');


### PR DESCRIPTION
The GET request to root fails because the server is expecting POST requests. It's very handy to have a healthcheck endpoint, so GET requests on root can always respond with 200.